### PR TITLE
Fixed #28

### DIFF
--- a/igamt-lite-client/app/scripts/controllers/datatypes.js
+++ b/igamt-lite-client/app/scripts/controllers/datatypes.js
@@ -466,9 +466,6 @@ angular.module('igl')
         };
 
         $scope.editVSModal = function(component) {
-            console.log(component.tables);
-            console.log($rootScope.tablesMap);
-            console.log($rootScope.tablesMap[component.tables[0].id]);
             var modalInstance = $modal.open({
                 templateUrl: 'editVSModal.html',
                 controller: 'EditVSCtrl',


### PR DESCRIPTION
XML Reserved Markup Characters are not escaped when creating a Plaintext Conformance statement #28